### PR TITLE
Remove calls to cv.destroyAllWindows() method

### DIFF
--- a/app/camera_dogzilla.py
+++ b/app/camera_dogzilla.py
@@ -111,4 +111,3 @@ if __name__ == '__main__':
         if k == 27 or k == ord('q'):
             break
     del camera
-    cv.destroyAllWindows()

--- a/demos/color.py
+++ b/demos/color.py
@@ -117,4 +117,3 @@ while 1:
         change_color()
 
 cap.release()
-cv2.destroyAllWindows() 

--- a/demos/hp.py
+++ b/demos/hp.py
@@ -40,4 +40,3 @@ while True:
 
  
 cap.release()
-cv2.destroyAllWindows()

--- a/demos/image_class.py
+++ b/demos/image_class.py
@@ -116,8 +116,6 @@ def run(model: str, max_results: int, score_threshold: float, num_threads: int,
       break
 
   cap.release()
-  cv2.destroyAllWindows()
-
 
 def main():
   parser = argparse.ArgumentParser(

--- a/demos/image_dete.py
+++ b/demos/image_dete.py
@@ -108,8 +108,6 @@ def run(model: str, camera_id: int, width: int, height: int, num_threads: int,
       break
 
   cap.release()
-  cv2.destroyAllWindows()
-
 
 def main():
   parser = argparse.ArgumentParser(

--- a/demos/network.py
+++ b/demos/network.py
@@ -133,4 +133,3 @@ while True:
         break
 
 cap.release()
-cv2.destroyAllWindows()

--- a/demos/qrcode.py
+++ b/demos/qrcode.py
@@ -53,4 +53,3 @@ while(True):
         break
 
 cap.release()
-cv2.destroyAllWindows() 

--- a/extra_demos/fit.py
+++ b/extra_demos/fit.py
@@ -164,4 +164,3 @@ with mp_pose.Pose(min_detection_confidence=0.5, min_tracking_confidence=0.5) as 
             break
     dog.reset()
     cap.release()
-    cv2.destroyAllWindows()

--- a/extra_demos/follow_line.py
+++ b/extra_demos/follow_line.py
@@ -113,4 +113,3 @@ if __name__ == '__main__':
             break
     
     capture.release()
-    cv.destroyAllWindows()

--- a/extra_demos/line.py
+++ b/extra_demos/line.py
@@ -114,4 +114,3 @@ if __name__ == '__main__':
             break
     
     capture.release()
-    cv.destroyAllWindows()

--- a/extra_demos/objectron.py
+++ b/extra_demos/objectron.py
@@ -146,4 +146,3 @@ while 1:
         change_color()
 
 cap.release()
-cv2.destroyAllWindows() 

--- a/tools/playvideo.py
+++ b/tools/playvideo.py
@@ -52,7 +52,6 @@ def PlayVideo(video_path):
 
 
     video.release()
-    cv2.destroyAllWindows()
 
 PlayVideo(video_path)
 


### PR DESCRIPTION
Calling this method leads to the error on headless systems:
```
Traceback (most recent call last):
  File "/home/pi/XGO-RaspberryPi-CM4/app/camera_dogzilla.py", line 114, in <module>
    cv.destroyAllWindows()
cv2.error: OpenCV(3.4.19) /mnt/ext/xgo2/buildroot/output/build/opencv3-3.4.19/modules/highgui/src/window.cpp:653: error: (-2:Unspecified error) The function is not implemented. Rebuild the library with Windows, GTK+ 2.x or Carbon support. If you are on Ubuntu or Debian, install libgtk2.0-dev and pkg-config, then re-run cmake or configure script in function 'cvDestroyAllWindows'
```
Removing these calls wouldn't affect any functionality